### PR TITLE
chore: overhaul rust project files (#2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "nuxt preview .playground",
     "postinstall": "nuxt prepare .playground && bun run wasm:bundle",
     "wasm:bundle": "cd wasm && wasm-pack build --target web --release",
+    "wasm:publish": "bun run wasm:bundle && wasm/rename-package.sh && wasm-pack pack wasm/pkg && wasm-pack publish wasm/pkg --tag next --access public",
     "lint": "eslint ."
   },
   "devDependencies": {

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "image"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/refilelabs/image"
+homepage = "https://refilelabs.com/image"
+keywords = ["image", "processing", "wasm", "web"]
 license-file = "../LICENSE"
-description = "Wasm image utilities"
+readme = "./README.md"
+description = "Wasm-based image processing library developed by re;file labs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-gloo-utils = { version = "0.2.0", features = ["serde"] }
 image = "0.25.5"
-js-sys = "0.3.72"
+js-sys = "0.3.73"
 kamadak-exif = "0.6.1"
 resvg = { version = "0.44.0", default-features = false, features = [
   "text",
@@ -22,16 +23,14 @@ resvg = { version = "0.44.0", default-features = false, features = [
 ] }
 serde = { version = "1.0.215", features = ["serde_derive"] }
 serde_json = { version = "1.0.133", default-features = false }
-# serde = { version = "1.0.203", features = ["serde_derive"] }
-# serde_json = "1.0.117"
-thiserror = "1.0.61"
+thiserror = "2.0.3"
 tsify = "0.4.5"
-wasm-bindgen = "0.2.95"
-
-[dependencies.web-sys]
-version = "0.3.72"
-features = ['Blob']
+wasm-bindgen = "0.2.96"
+web-sys = { version = "0.3.73", features = ["Blob"] }
 
 [profile.release]
 lto = true
 opt-level = "s"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Oz', '--enable-bulk-memory']

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,130 @@
+# @refilelabs/image
+
+A WebAssembly-powered library for advanced image manipulation and format conversion. This package provides tools for loading image metadata, converting images, and retrieving raw pixel data—all in the browser or Node.js environment.
+
+It is used under the hood at [re;file labs' image tools](https://refilelabs.com/image) to power the different image processing features.
+
+## Installation
+
+```bash
+npm install @refilelabs/image
+```
+
+## Features
+
+- Load image metadata
+- Retrieve raw RGBA pixel data and image properties
+- Convert images between different formats
+- Supports custom conversion settings
+
+## API Reference
+
+### `loadMetadata(file: Uint8Array, src_type: string, cb: Function): Metadata`
+
+Loads the metadata of an image file.
+
+#### Parameters:
+- `file` (`Uint8Array`): The image file to analyze.
+- `src_type` (`string`): The MIME type of the source image (e.g., `image/png`, `image/jpeg`).
+- `cb` (`Function`): A callback function to report progress.
+
+#### Returns:
+- `Metadata`: An object containing image metadata (e.g., width, height, other information).
+
+---
+
+### `getPixels(file: Uint8Array, src_type: string): ImageData`
+
+Converts an image file to raw RGBA pixel data.
+
+#### Parameters:
+- `file` (`Uint8Array`): The image file to convert.
+- `src_type` (`string`): The MIME type of the source image.
+
+#### Returns:
+- `ImageData`: An object containing raw pixel data and image properties (e.g., width, height, color depth).
+
+---
+
+### `convertImage(file: Uint8Array, src_type: string, target_type: string, cb: Function, convert_settings?: Settings): Uint8Array`
+
+Converts an image from one format to another.
+
+#### Parameters:
+- `file` (`Uint8Array`): The image file to convert.
+- `src_type` (`string`): The MIME type of the source image.
+- `target_type` (`string`): The target MIME type (e.g., `image/webp`, `image/png`).
+- `cb` (`Function`): A callback function to report progress.
+- `convert_settings` (`Settings`, optional): Settings for the conversion (e.g., for SVG).
+
+#### Returns:
+- `Uint8Array`: The converted image data.
+
+---
+
+### Interfaces
+
+#### `Metadata`
+
+Represents metadata of an image.
+
+- `width` (`number`): Image width.
+- `height` (`number`): Image height.
+- `other` (`Record<string, string> | null`): Additional metadata.
+
+---
+
+#### `ImageData`
+
+Represents raw image data.
+
+- `width` (`number`): Image width.
+- `height` (`number`): Image height.
+- `aspect_ratio` (`number`): Aspect ratio.
+- `color_depth` (`number`): Color depth.
+- `pixels` (`number[]`): Raw RGBA pixel values.
+
+---
+
+#### `SvgSettings`
+
+Settings specific to SVG format.
+
+- `width` (`number`): SVG width.
+- `height` (`number`): SVG height.
+
+---
+
+#### `Settings`
+
+Settings for conversion.
+
+- `type`: `"svg"` for SVG settings.
+- Includes all properties of `SvgSettings`.
+
+---
+
+## Usage Example
+
+```javascript
+import init, { loadMetadata, getPixels, convertImage } from '@refilelabs/image';
+
+await init();
+
+const file = new Uint8Array(/* ... */);
+const srcType = 'image/png';
+const targetType = 'image/webp';
+
+const metadata = loadMetadata(file, srcType, (progress) => console.log(`Progress: ${progress}%`));
+console.log('Metadata:', metadata);
+
+const imageData = getPixels(file, srcType);
+console.log('Image Data:', imageData);
+
+const converted = convertImage(file, srcType, targetType, (progress) => console.log(`Progress: ${progress}%`));
+console.log('Converted Image:', converted);
+```
+
+## License
+
+MIT

--- a/wasm/rename-package.sh
+++ b/wasm/rename-package.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Update the "name" field in pkg/package.json files
+
+# Define the old and new names
+OLD_NAME='"name": "image"'
+NEW_NAME='"name": "@refilelabs/image"'
+
+# Find all pkg/package.json files and update the "name" field
+find . -path '*/pkg/package.json' -type f | while read -r file; do
+    if grep -q "$OLD_NAME" "$file"; then
+        sed -i.bak "s|$OLD_NAME|$NEW_NAME|" "$file" && echo "Updated $file"
+        rm "$file.bak" # Remove backup file created by sed
+    else
+        echo "No match found in $file, skipping."
+    fi
+done
+
+echo "Renaming completed."

--- a/wasm/src/convert/settings.rs
+++ b/wasm/src/convert/settings.rs
@@ -1,4 +1,4 @@
-#[derive(tsify::Tsify, serde::Deserialize)]
+#[derive(tsify::Tsify, serde::Deserialize, serde::Serialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(tag = "type")]
 pub enum Settings {
@@ -6,7 +6,7 @@ pub enum Settings {
     Svg(SvgSettings),
 }
 
-#[derive(tsify::Tsify, serde::Deserialize, Copy, Clone)]
+#[derive(tsify::Tsify, serde::Deserialize, serde::Serialize, Copy, Clone)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct SvgSettings {
     pub width: u32,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(trivial_bounds)]
 #![warn(clippy::pedantic)]
 #![allow(
     clippy::module_name_repetitions,

--- a/wasm/src/metadata.rs
+++ b/wasm/src/metadata.rs
@@ -11,7 +11,7 @@ use crate::{
     source_type::SourceType,
 };
 
-#[derive(tsify::Tsify, serde::Serialize, Default)]
+#[derive(tsify::Tsify, serde::Deserialize, serde::Serialize, Default)]
 #[tsify(from_wasm_abi, into_wasm_abi)]
 pub struct Metadata {
     pub width: u32,

--- a/wasm/src/view.rs
+++ b/wasm/src/view.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{load::load_image, source_type::SourceType};
 
-#[derive(tsify::Tsify, serde::Serialize, Default)]
+#[derive(tsify::Tsify, serde::Serialize, serde::Deserialize, Default)]
 #[tsify(from_wasm_abi, into_wasm_abi)]
 pub struct ImageData {
     pub width: u32,


### PR DESCRIPTION
This PR aims to resolve #2

It aims to provide compatibility with the newest wasm-pack & wasm-opt versions.
To ensure this, the following arguments are passed to wasm-opt:
```toml
[package.metadata.wasm-pack.profile.release]
wasm-opt = ['-Oz', '--enable-bulk-memory']
```
This not only adds compatibility to current version (using `--enable-bulk-memory`) but also adds further size-optimizations using `-Oz`, further shrinking the .wasm files' size to about 3.8mb

Achieving compatibility with the stable toolchain forced me to remove the unstable `trivial_bounds` feature. Because of this the types used by `tsify` now have to always implement both serialize and deserialize. 
However, I think this is a minor tradeoff in exchange for making this usable with the stable toolchain.

Let me know what you think @arunavo4 and whether this helped you :)
